### PR TITLE
Add option for different grain size formulations

### DIFF
--- a/doc/modules/changes/20221031_gassmoeller
+++ b/doc/modules/changes/20221031_gassmoeller
@@ -1,0 +1,6 @@
+Changed: The 'grain size' material model now supports additional formulations
+for grain size evolution. For this purpose the old input parameter 'Use paleowattmeter'
+has been deprecated and replaced with 'Grain size evolution formulation'. The
+default behavior of the material model has not changed.
+<br>
+(Rene Gassmoeller, 2022/10/31)

--- a/include/aspect/material_model/grain_size.h
+++ b/include/aspect/material_model/grain_size.h
@@ -201,11 +201,55 @@ namespace aspect
          * set to false we use the approach of Hall, C. E.,
          * Parmentier, E. M. (2003). Influence of grain size evolution on
          * convective instability. Geochemistry, Geophysics, Geosystems, 4(3).
+         * Or: TODO add Mulyukova reference.
          */
-        bool use_paleowattmeter;
         std::vector<double> grain_boundary_energy;
         std::vector<double> boundary_area_change_work_fraction;
         std::vector<double> geometric_constant;
+
+        /**
+          * A struct that contains information about which
+          * formulation of grain size evolution should be used.
+          */
+        struct Formulation
+        {
+          /**
+           * This enum lists available options that
+           * determine the dynamic recrystallization.
+           */
+          enum Kind
+          {
+            paleowattmeter,
+            paleopiezometer,
+            pinned_grain_damage
+          };
+
+          /**
+           * This function translates an input string into the
+           * available enum options.
+           */
+          static
+          Kind
+          parse(const std::string &input)
+          {
+            if (input == "paleowattmeter")
+              return Formulation::paleowattmeter;
+            else if (input == "paleopiezometer")
+              return Formulation::paleopiezometer;
+            else if (input == "pinned grain damage")
+              return Formulation::pinned_grain_damage;
+            else
+              AssertThrow(false, ExcNotImplemented());
+
+            return Formulation::Kind();
+          }
+        };
+
+        /**
+         * A variable that records the formulation of how to evolve grain size.
+         * See the type of this variable for a description of available options.
+        */
+        typename Formulation::Kind grain_size_evolution_formulation;
 
         /**
          * Parameters controlling the viscosity.

--- a/include/aspect/material_model/grain_size.h
+++ b/include/aspect/material_model/grain_size.h
@@ -195,13 +195,6 @@ namespace aspect
 
         /**
          * Parameters controlling the dynamic grain recrystallization.
-         * (following paleowattmeter as described in Austin, N. J., & Evans, B.
-         * (2007). Paleowattmeters: A scaling relation for dynamically
-         * recrystallized grain size. Geology, 35(4), 343-346.). If this is
-         * set to false we use the approach of Hall, C. E.,
-         * Parmentier, E. M. (2003). Influence of grain size evolution on
-         * convective instability. Geochemistry, Geophysics, Geosystems, 4(3).
-         * Or: TODO add Mulyukova reference.
          */
         std::vector<double> grain_boundary_energy;
         std::vector<double> boundary_area_change_work_fraction;
@@ -215,7 +208,23 @@ namespace aspect
         {
           /**
            * This enum lists available options that
-           * determine the dynamic recrystallization.
+           * determine the equations being used for grain size evolution.
+           *
+           * We currently support three approaches:
+           *
+           * 'paleowattmeter':
+           * Austin, N. J., & Evans, B. (2007). Paleowattmeters: A scaling
+           * relation for dynamically recrystallized grain size. Geology, 354), 343-346.).
+           *
+           * 'paleopiezometer':
+           * Hall, C. E., Parmentier, E. M. (2003). Influence of grain size
+           * evolution on convective instability. Geochemistry, Geophysics,
+           * Geosystems, 4(3).
+           *
+           * 'pinned_grain_damage':
+           * Mulyukova, E., & Bercovici, D. (2018). Collapse of passive margins
+           * by lithospheric damage and plunging grain size. Earth and Planetary
+           * Science Letters, 484, 341-352.
            */
           enum Kind
           {

--- a/source/material_model/grain_size.cc
+++ b/source/material_model/grain_size.cc
@@ -1066,16 +1066,18 @@ namespace aspect
                              "Units: \\si{\\meter}.");
           prm.declare_entry ("Grain size evolution formulation", "paleowattmeter",
                              Patterns::Selection ("paleowattmeter|paleopiezometer|pinned grain damage"),
-                             "A flag indicating whether the computation should be use the "
+                             "A flag indicating whether the material model should use the "
                              "paleowattmeter approach of Austin and Evans (2007) for grain size reduction "
-                             "in the dislocation creep regime (if true) or the paleopiezometer approach "
-                             "from Hall and Parmetier (2003) (if false). TODO update.");
+                             "in the dislocation creep regime, the paleopiezometer approach "
+                             "from Hall and Parmetier (2003), or the pinned grain damage approach "
+                             "from Mulyukova and Bercovici (2018).");
           prm.declare_entry ("Use paleowattmeter", "default",
                              Patterns::Selection ("true|false|default"),
-                             "A flag indicating whether the computation should be use the "
+                             "A flag indicating whether the computation should use the "
                              "paleowattmeter approach of Austin and Evans (2007) for grain size reduction "
                              "in the dislocation creep regime (if true) or the paleopiezometer approach "
-                             "from Hall and Parmetier (2003) (if false).");
+                             "from Hall and Parmetier (2003) (if false). This parameter has been removed. "
+                             "Use 'Grain size evolution formulation' instead.");
           prm.declare_entry ("Average specific grain boundary energy", "1.0",
                              Patterns::List (Patterns::Double (0.)),
                              "The average specific grain boundary energy $\\gamma$. "
@@ -1304,11 +1306,12 @@ namespace aspect
           reciprocal_required_strain            = Utilities::string_to_double
                                                   (Utilities::split_string_list(prm.get ("Reciprocal required strain")));
 
-          grain_size_evolution_formulation                    = Formulation::parse(prm.get("Grain size evolution formulation"));
+          grain_size_evolution_formulation      = Formulation::parse(prm.get("Grain size evolution formulation"));
 
-          std::string use_paleowattmeter = prm.get ("Use paleowattmeter");
+          const std::string use_paleowattmeter  = prm.get ("Use paleowattmeter");
           Assert(use_paleowattmeter == "default",
-                 ExcMessage("The parameter 'Use paleowattmeter' is deprecated. Use the parameter 'Grain size evolution formulation instead'."));
+                 ExcMessage("The parameter 'Use paleowattmeter' has been removed. "
+                            "Use the parameter 'Grain size evolution formulation instead'."));
 
 
           grain_boundary_energy                 = Utilities::string_to_double

--- a/tests/grain_size_friction_heating.prm
+++ b/tests/grain_size_friction_heating.prm
@@ -106,7 +106,7 @@ subsection Material model
     set Average specific grain boundary energy = 1.0
     set Work fraction for boundary area change = 0.1
     set Geometric constant                   = 3
-    set Use paleowattmeter                          = true
+    set Grain size evolution formulation     = paleowattmeter
     set Reciprocal required strain                  = 10
 
     # Faul and Jackson 2007

--- a/tests/grain_size_growth.prm
+++ b/tests/grain_size_growth.prm
@@ -131,7 +131,7 @@ subsection Material model
     set Grain growth activation volume       = 0.0
     set Grain growth rate constant           = 4E-045
     set Grain growth exponent                = 10
-    set Use paleowattmeter                   = false
+    set Grain size evolution formulation     = paleowattmeter
     set Reciprocal required strain           = 0
 
     # Faul and Jackson 2007

--- a/tests/grain_size_growth_log.prm
+++ b/tests/grain_size_growth_log.prm
@@ -130,7 +130,7 @@ subsection Material model
     set Grain growth activation volume       = 0.0
     set Grain growth rate constant           = 4E-045
     set Grain growth exponent                = 10
-    set Use paleowattmeter                   = false
+    set Grain size evolution formulation     = paleowattmeter
     set Reciprocal required strain           = 0
 
     set Advect logarithm of grain size       = true

--- a/tests/grain_size_growth_scaled.prm
+++ b/tests/grain_size_growth_scaled.prm
@@ -133,7 +133,7 @@ subsection Material model
     set Grain growth activation volume       = 0.0
     set Grain growth rate constant           = 4E-045
     set Grain growth exponent                = 10
-    set Use paleowattmeter                   = false
+    set Grain size evolution formulation     = paleowattmeter
     set Reciprocal required strain           = 0
 
     set Lower mantle grain size scaling      = 10

--- a/tests/grain_size_strain.prm
+++ b/tests/grain_size_strain.prm
@@ -105,7 +105,7 @@ subsection Material model
     set Average specific grain boundary energy = 1.0
     set Work fraction for boundary area change = 0.1
     set Geometric constant                   = 3
-    set Use paleowattmeter                          = true
+    set Grain size evolution formulation     = paleowattmeter
     set Reciprocal required strain                  = 10
 
     # Faul and Jackson 2007


### PR DESCRIPTION
This PR adds an `enum` that can represent the different grain size evolution equations we are using. So far I have kept the existing options and already added a new one that does nothing at the moment (it currently behaves identical to the paleopiezometer).

I have tested that all tests still give the same results.