### PR TITLE
make new shear heating output

### DIFF
--- a/include/aspect/heating_model/shear_heating.h
+++ b/include/aspect/heating_model/shear_heating.h
@@ -61,6 +61,29 @@ namespace aspect
         void
         create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &material_model_outputs) const override;
     };
+
+
+    /**
+     * Additional output fields for the shear heating computation
+     * to be added to the MaterialModel::MaterialModelOutputs structure
+     * and filled in the MaterialModel::evaluate() function.
+     */
+    template <int dim>
+    class ShearHeatingOutputs : public MaterialModel::NamedAdditionalMaterialOutputs<dim>
+    {
+      public:
+    	ShearHeatingOutputs(const unsigned int n_points);
+
+        std::vector<double> get_nth_output(const unsigned int idx) const override;
+
+        /**
+         * The fraction of the deformation work that is released as shear heating
+         * rather than being converted into other forms of energy (such as, for
+         * example, surface energy of grains). If it is set to 1, all deformation
+         * work will go into shear heating.
+         */
+        std::vector<double> shear_heating_work_fractions;
+    };
   }
 }
 

--- a/source/heating_model/shear_heating.cc
+++ b/source/heating_model/shear_heating.cc
@@ -20,7 +20,6 @@
 
 
 #include <aspect/heating_model/shear_heating.h>
-#include <aspect/material_model/grain_size.h>
 
 
 namespace aspect
@@ -42,8 +41,8 @@ namespace aspect
 
       // Some material models provide dislocation viscosities and boundary area work fractions
       // as additional material outputs. If they are attached, use them.
-      const MaterialModel::DislocationViscosityOutputs<dim> *disl_viscosities_out =
-        material_model_outputs.template get_additional_output<MaterialModel::DislocationViscosityOutputs<dim>>();
+      const ShearHeatingOutputs<dim> *shear_heating_out =
+        material_model_outputs.template get_additional_output<ShearHeatingOutputs<dim>>();
 
       for (unsigned int q=0; q<heating_model_outputs.heating_source_terms.size(); ++q)
         {
@@ -61,12 +60,11 @@ namespace aspect
 
           heating_model_outputs.heating_source_terms[q] = stress * deviatoric_strain_rate;
 
-          // If dislocation viscosities and boundary area work fractions are provided, reduce the
-          // overall heating by this amount (which is assumed to increase surface energy)
-          if (disl_viscosities_out != nullptr)
+          // If shear heating work fractions are provided, reduce the
+          // overall heating by this amount (which is assumed to converted into aother forms of energy)
+          if (shear_heating_out != nullptr)
             {
-              heating_model_outputs.heating_source_terms[q] *= 1 - disl_viscosities_out->boundary_area_change_work_fractions[q] *
-                                                               material_model_outputs.viscosities[q] / disl_viscosities_out->dislocation_viscosities[q];
+              heating_model_outputs.heating_source_terms[q] *= shear_heating_out->shear_heating_work_fractions[q];
             }
 
           heating_model_outputs.lhs_latent_heat_terms[q] = 0.0;
@@ -79,6 +77,38 @@ namespace aspect
     create_additional_material_model_outputs(MaterialModel::MaterialModelOutputs<dim> &material_model_outputs) const
     {
       this->get_material_model().create_additional_named_outputs(material_model_outputs);
+    }
+
+
+
+    namespace
+    {
+      std::vector<std::string> make_shear_heating_outputs_names()
+      {
+        std::vector<std::string> names;
+        names.emplace_back("shear_heating_work_fraction");
+        return names;
+      }
+    }
+
+
+
+    template <int dim>
+    ShearHeatingOutputs<dim>::ShearHeatingOutputs (const unsigned int n_points)
+      :
+	  MaterialModel::NamedAdditionalMaterialOutputs<dim>(make_shear_heating_outputs_names()),
+	  shear_heating_work_fractions(n_points, numbers::signaling_nan<double>())
+    {}
+
+
+
+    template <int dim>
+    std::vector<double>
+    ShearHeatingOutputs<dim>::get_nth_output(const unsigned int idx) const
+    {
+      AssertIndexRange (idx, 0);
+
+      return shear_heating_work_fractions;
     }
   }
 }
@@ -96,5 +126,12 @@ namespace aspect
                                   "\\varepsilon \\mathbf 1 \\right) : \\left( \\varepsilon - \\frac{1}{3} "
                                   "\\text{tr} \\varepsilon \\mathbf 1 \\right)$ to the "
                                   "right-hand side of the temperature equation.")
+
+#define INSTANTIATE(dim) \
+  template class ShearHeatingOutputs<dim>;
+
+    ASPECT_INSTANTIATE(INSTANTIATE)
+
+#undef INSTANTIATE
   }
 }

--- a/source/material_model/grain_size.cc
+++ b/source/material_model/grain_size.cc
@@ -22,6 +22,7 @@
 #include <aspect/material_model/grain_size.h>
 #include <aspect/adiabatic_conditions/interface.h>
 #include <aspect/gravity_model/interface.h>
+#include <aspect/heating_model/shear_heating.h>
 #include <aspect/utilities.h>
 
 #include <deal.II/base/quadrature_lib.h>
@@ -862,6 +863,12 @@ namespace aspect
                   disl_viscosities_out->dislocation_viscosities[i] = std::min(std::max(min_eta,disl_viscosity),1e300);
                   disl_viscosities_out->diffusion_viscosities[i] = std::min(std::max(min_eta,diff_viscosity),1e300);
                 }
+
+              if (HeatingModel::ShearHeatingOutputs<dim> *shear_heating_out = out.template get_additional_output<HeatingModel::ShearHeatingOutputs<dim>>())
+                {
+            	  const double f = boundary_area_change_work_fraction[get_phase_index(in.position[i],in.temperature[i],pressure)];
+            	  shear_heating_out->shear_heating_work_fractions[i] = 1. - f * out.viscosities[i] / std::min(std::max(min_eta,disl_viscosity),1e300);
+                }
             }
 
           out.densities[i] = density(in.temperature[i], pressure, in.composition[i], in.position[i]);
@@ -1468,14 +1475,21 @@ namespace aspect
     void
     GrainSize<dim>::create_additional_named_outputs (MaterialModel::MaterialModelOutputs<dim> &out) const
     {
-      // These properties are useful as output, but will also be used by the
-      // heating model to reduce shear heating by the amount of work done to
-      // reduce grain size.
+      // These properties are useful as output.
       if (out.template get_additional_output<DislocationViscosityOutputs<dim>>() == nullptr)
         {
           const unsigned int n_points = out.n_evaluation_points();
           out.additional_outputs.push_back(
             std::make_unique<MaterialModel::DislocationViscosityOutputs<dim>> (n_points));
+        }
+
+      // These properties will be used by the heating model to reduce
+      // shear heating by the amount of work done to reduce grain size.
+      if (out.template get_additional_output<HeatingModel::ShearHeatingOutputs<dim>>() == nullptr)
+        {
+          const unsigned int n_points = out.n_evaluation_points();
+          out.additional_outputs.push_back(
+            std::make_unique<HeatingModel::ShearHeatingOutputs<dim>> (n_points));
         }
 
       // These properties are only output properties.


### PR DESCRIPTION
This PR creates a new additional material model output that contains the fraction of work that goes into shear heating. I checked that the `DislocationViscosityOutputs`, which were used for that purpose before, are only used in the grain size material model. 
grain_size_latent_heat

I have run the grain size tests locally to check that this PR does not affect the results. There is a very small change in the `grain_size_latent_heat` test, but that fails on my machine with aspect master as well. 