### PR TITLE
change shear heating output to use the new grain size formulation

### DIFF
--- a/source/material_model/grain_size.cc
+++ b/source/material_model/grain_size.cc
@@ -272,7 +272,7 @@ namespace aspect
                                                        / (geometric_constant[phase_index] * grain_boundary_energy[phase_index]);
               grain_size_reduction = grain_size_reduction_rate * grain_growth_timestep;
             }
-          else if (grain_size_evolution_formulation == Formulation::pinned_grain_damage)  
+          else if (grain_size_evolution_formulation == Formulation::pinned_grain_damage)
             {
               // pinned_grain_damage: Mulyukova and Bercovici (2018) Collapse of passive margins by lithospheric damage and plunging grain size. Earth and Planetary Science Letters, 484, 341-352.
               const double stress = 2.0 * second_strain_rate_invariant * current_viscosity;
@@ -870,8 +870,20 @@ namespace aspect
 
               if (HeatingModel::ShearHeatingOutputs<dim> *shear_heating_out = out.template get_additional_output<HeatingModel::ShearHeatingOutputs<dim>>())
                 {
-                  const double f = boundary_area_change_work_fraction[get_phase_index(in.position[i],in.temperature[i],pressure)];
-                  shear_heating_out->shear_heating_work_fractions[i] = 1. - f * out.viscosities[i] / std::min(std::max(min_eta,disl_viscosity),1e300);
+                  if (grain_size_evolution_formulation == Formulation::paleowattmeter ||
+                      grain_size_evolution_formulation == Formulation::paleopiezometer)
+                    {
+                      const double f = boundary_area_change_work_fraction[get_phase_index(in.position[i],in.temperature[i],pressure)];
+                      shear_heating_out->shear_heating_work_fractions[i] = 1. - f * out.viscosities[i] / std::min(std::max(min_eta,disl_viscosity),1e300);
+                    }
+                  else if (grain_size_evolution_formulation == Formulation::pinned_grain_damage)
+                    {
+                      // TODO: f still needs to be updated with the new T-dependent parameter
+                      const double f = boundary_area_change_work_fraction[get_phase_index(in.position[i],in.temperature[i],pressure)];
+                      shear_heating_out->shear_heating_work_fractions[i] = 1. - f;
+                    }
+                  else
+                    AssertThrow(false, ExcNotImplemented());
                 }
             }
 


### PR DESCRIPTION
This adds the correct shear heating term for the new formulation. However, this still requires the new temperature-dependent f to be used (so it is connected to #6). 

In addition, I realized that the original way this was implemented makes no sense for the paleopiezometer (since we figured out today that it does not use the boundary area change work fraction). I left the old implementation the way it was, but we should discuss at some point how to deal with that (add an Assert so that paleopiezometer and shear heating cannot be used together?). 
 
* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

### For new features/models or changes of existing features:

* [ ] I have tested my new feature locally to ensure it is correct.
* [ ] I have [created a testcase](http://www.math.clemson.edu/~heister/manual.pdf#sec%3Awriting_tests) for the new feature/benchmark in the [tests/](../blob/main/tests/) directory.
* [ ] I have added a changelog entry in the [doc/modules/changes](../blob/main/doc/modules/changes) directory that will inform other users of my change.
