### PR TITLE
Add test file using the parameters from Mulyukova and Bercovici.

### DIFF
--- a/tests/grain_size_strain_pinned_state.prm
+++ b/tests/grain_size_strain_pinned_state.prm
@@ -1,8 +1,8 @@
 # A test for the grain size material model using pinned state damage formulation. 
 # Over time the model maintains nearly constant temperatures, pressures and
 # strain rates. The grain size in the test approaches the equilibrium
-# grain size for t -> infinity. At 4 Myr the grain size is
-# 9.35850647e-04 m, which is close to the equilibrium value.
+# grain size for t -> infinity. At 4 Myr the equilibrium grain size should
+# 1.39858e-1 m.
 
 include grain_size_strain.prm
 
@@ -21,7 +21,7 @@ subsection Material model
     set Reference temperature            = 1600
     set Recrystallized grain size        =
 
-    set Grain growth activation energy       = 3e5
+    set Grain growth activation energy       = 39072
     set Grain growth activation volume       = 0.0
 #    set Grain growth rate constant           = 1.92E-010
     set Grain growth exponent                = 4
@@ -31,7 +31,7 @@ subsection Material model
 
     # Mulyukova and Bercovici (2018)
     # Diffusion creep
-    set Diffusion creep prefactor            =13.6e-24 # s^-1 Pa^-1 m^p
+    set Diffusion creep prefactor            =1e-40 # s^-1 Pa^-1 m^p
     set Diffusion creep exponent             =1.0 # 1 for diffusion creep
     set Diffusion creep grain size exponent  =3
     set Diffusion activation energy          =3e5 #J/mol
@@ -40,9 +40,9 @@ subsection Material model
     set Dislocation viscosity iteration threshold = 1e-3
     # Kawazoe et al. (2009)
     # Dislocation creep
-    set Dislocation creep prefactor          =1.1e-13 # s^-1 Pa^-n
+    set Dislocation creep prefactor          =1e-13 # s^-1 Pa^-n
     set Dislocation creep exponent           =3
-    set Dislocation activation energy        =530000 # J/mol
+    set Dislocation activation energy        =390720 # J/mol
     set Dislocation activation volume        =0 # m^3/mol
   end
 end

--- a/tests/grain_size_strain_pinned_state.prm
+++ b/tests/grain_size_strain_pinned_state.prm
@@ -1,13 +1,12 @@
 # A test for the grain size material model using pinned state damage formulation. 
 # Over time the model maintains nearly constant temperatures, pressures and
 # strain rates. The grain size in the test approaches the equilibrium
-# grain size for t -> infinity. At 4 Myr the equilibrium grain size should
-# be 2.37501e-1 m.
+# grain size for t -> infinity. At 200 Myr the equilibrium grain size should
+# be 0.0165746 m.
 
 include grain_size_strain.prm
 
-set End time                               = 4e6
-set Output directory                       = grain_size_strain_pinned_state
+set Output directory                       = output_grain_size_strain_pinned_state
 
 subsection Material model
   set Model name = grain size
@@ -45,12 +44,9 @@ subsection Material model
     set Dislocation creep exponent           =3
     set Dislocation activation energy        =390720 # J/mol
     set Dislocation activation volume        =0 # m^3/mol
-  end
-end
 
-subsection Postprocess
-  set List of postprocessors = visualization
-  subsection Visualization
-    set Time between graphical output = 1e5
+    subsection Grain damage partitioning
+      set Minimum grain size reduction work fraction = 1e-6
+    end
   end
 end

--- a/tests/grain_size_strain_pinned_state.prm
+++ b/tests/grain_size_strain_pinned_state.prm
@@ -1,0 +1,48 @@
+# A test for the grain size material model using pinned state damage formulation. 
+# Over time the model maintains nearly constant temperatures, pressures and
+# strain rates. The grain size in the test approaches the equilibrium
+# grain size for t -> infinity. At 4 Myr the grain size is
+# 9.35850647e-04 m, which is close to the equilibrium value.
+
+include grain_size_strain.prm
+
+set End time                               = 5000
+
+subsection Material model
+  set Model name = grain size
+
+  subsection Grain size model
+    set Reference density                = 3400
+    set Thermal conductivity             = 0
+    set Thermal expansion coefficient    = 0
+    set Reference compressibility        = 0
+    set Viscosity                        = 1e18
+    set Minimum viscosity                = 1e16
+    set Reference temperature            = 1600
+    set Recrystallized grain size        =
+
+    set Grain growth activation energy       = 3e5
+    set Grain growth activation volume       = 0.0
+#    set Grain growth rate constant           = 1.92E-010
+    set Grain growth exponent                = 4
+    set Average specific grain boundary energy = 1.0
+    set Geometric constant                   = 3
+    set Grain size evolution formulation     = pinned grain damage
+
+    # Mulyukova and Bercovici (2018)
+    # Diffusion creep
+    set Diffusion creep prefactor            =13.6e-24 # s^-1 Pa^-1 m^p
+    set Diffusion creep exponent             =1.0 # 1 for diffusion creep
+    set Diffusion creep grain size exponent  =3
+    set Diffusion activation energy          =3e5 #J/mol
+    set Diffusion activation volume          =0 # m^3/mol
+
+    set Dislocation viscosity iteration threshold = 1e-3
+    # Kawazoe et al. (2009)
+    # Dislocation creep
+    set Dislocation creep prefactor          =1.1e-13 # s^-1 Pa^-n
+    set Dislocation creep exponent           =3
+    set Dislocation activation energy        =530000 # J/mol
+    set Dislocation activation volume        =0 # m^3/mol
+  end
+end

--- a/tests/grain_size_strain_pinned_state.prm
+++ b/tests/grain_size_strain_pinned_state.prm
@@ -2,11 +2,12 @@
 # Over time the model maintains nearly constant temperatures, pressures and
 # strain rates. The grain size in the test approaches the equilibrium
 # grain size for t -> infinity. At 4 Myr the equilibrium grain size should
-# 1.39858e-1 m.
+# be 2.37501e-1 m.
 
 include grain_size_strain.prm
 
-set End time                               = 5000
+set End time                               = 4e6
+set Output directory                       = grain_size_strain_pinned_state
 
 subsection Material model
   set Model name = grain size
@@ -23,7 +24,7 @@ subsection Material model
 
     set Grain growth activation energy       = 39072
     set Grain growth activation volume       = 0.0
-#    set Grain growth rate constant           = 1.92E-010
+    set Grain growth rate constant           = 1.6E-022
     set Grain growth exponent                = 4
     set Average specific grain boundary energy = 1.0
     set Geometric constant                   = 3
@@ -31,7 +32,7 @@ subsection Material model
 
     # Mulyukova and Bercovici (2018)
     # Diffusion creep
-    set Diffusion creep prefactor            =1e-40 # s^-1 Pa^-1 m^p
+    set Diffusion creep prefactor            =1e-200 # s^-1 Pa^-1 m^p
     set Diffusion creep exponent             =1.0 # 1 for diffusion creep
     set Diffusion creep grain size exponent  =3
     set Diffusion activation energy          =3e5 #J/mol
@@ -44,5 +45,12 @@ subsection Material model
     set Dislocation creep exponent           =3
     set Dislocation activation energy        =390720 # J/mol
     set Dislocation activation volume        =0 # m^3/mol
+  end
+end
+
+subsection Postprocess
+  set List of postprocessors = visualization
+  subsection Visualization
+    set Time between graphical output = 1e5
   end
 end

--- a/tests/grain_size_strain_pinned_state/screen-output
+++ b/tests/grain_size_strain_pinned_state/screen-output
@@ -1,0 +1,50 @@
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+Number of active cells: 256 (on 5 levels)
+Number of degrees of freedom: 4,645 (2,178+289+1,089+1,089)
+
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 30+0 iterations.
+
+   Postprocessing:
+     Compositions min/max/mass: 0.001/0.001/1e+07
+     Temperature min/avg/max:   1600 K, 1600 K, 1600 K
+     RMS, max velocity:         0.577 m/year, 0.993 m/year
+
+*** Timestep 1:  t=3125 years, dt=3125 years
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 18 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 36+0 iterations.
+
+   Postprocessing:
+     Compositions min/max/mass: 0.001482/0.001482/1.482e+07
+     Temperature min/avg/max:   1600 K, 1600 K, 1600 K
+     RMS, max velocity:         0.577 m/year, 0.993 m/year
+
+*** Timestep 2:  t=5000 years, dt=1875 years
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 10 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 36+0 iterations.
+
+   Postprocessing:
+     Compositions min/max/mass: 0.001629/0.001629/1.629e+07
+     Temperature min/avg/max:   1600 K, 1600 K, 1600 K
+     RMS, max velocity:         0.577 m/year, 0.993 m/year
+
+Termination requested by criterion: end time
+
+
++----------------------------------------------+------------+------------+
++----------------------------------+-----------+------------+------------+
++----------------------------------+-----------+------------+------------+
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------

--- a/tests/grain_size_strain_pinned_state/statistics
+++ b/tests/grain_size_strain_pinned_state/statistics
@@ -1,0 +1,24 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of degrees of freedom for all compositions
+# 8: Iterations for temperature solver
+# 9: Iterations for composition solver 1
+# 10: Iterations for Stokes solver
+# 11: Velocity iterations in Stokes preconditioner
+# 12: Schur complement iterations in Stokes preconditioner
+# 13: Minimal value for composition grain_size
+# 14: Maximal value for composition grain_size
+# 15: Global mass for composition grain_size
+# 16: Minimal temperature (K)
+# 17: Average temperature (K)
+# 18: Maximal temperature (K)
+# 19: Average nondimensional temperature (K)
+# 20: RMS velocity (m/year)
+# 21: Max. velocity (m/year)
+0 0.000000000000e+00 0.000000000000e+00 256 2467 1089 1089 0  0 29 31  92 1.00000000e-03 1.00000010e-03 1.00000005e+07 1.60000000e+03 1.60000000e+03 1.60000000e+03 3.73686192e-15 5.77350267e-01 9.92956152e-01 
+1 3.125000000000e+03 3.125000000000e+03 256 2467 1089 1089 0 18 35 37 111 1.48212878e-03 1.48212881e-03 1.48212879e+07 1.60000000e+03 1.60000000e+03 1.60000000e+03 3.73686192e-15 5.77349857e-01 9.92956165e-01 
+2 5.000000000000e+03 1.875000000000e+03 256 2467 1089 1089 0 10 35 37 111 1.62851914e-03 1.62851916e-03 1.62851915e+07 1.60000000e+03 1.60000000e+03 1.60000000e+03 3.73686192e-15 5.77350077e-01 9.92956157e-01 


### PR DESCRIPTION
This PR adds the grain growth and reduction parameters using Mulyukova and Bercovici (2018) in the pinned state limit. Currently, the grain growth prefactor is not implemented from their paper because of unit conversion terms (\micro m to m), which was not straightforward.


* [x] I have read the guidelines in our [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) document.

### For all pull requests:

* [x] I have followed the [instructions for indenting my code](../blob/main/CONTRIBUTING.md#making-aspect-better).

