### PR TITLE
Only assert if parameter is read. Fix tests.

### DIFF
--- a/source/material_model/grain_size.cc
+++ b/source/material_model/grain_size.cc
@@ -1366,13 +1366,13 @@ namespace aspect
                 surface_temperature                         = prm.get_double ("Surface temperature");
               }
               prm.leave_subsection();
+
+              AssertThrow( (maximum_grain_size_reduction_work_fraction > 0. && maximum_grain_size_reduction_work_fraction < 1.),
+                           ExcMessage("Error: Maximum grain size reduction fraction must be between (0, 1)!"));
+
+              AssertThrow( (minimum_grain_size_reduction_work_fraction > 0. && minimum_grain_size_reduction_work_fraction < 1.),
+                           ExcMessage("Error: Minimum grain size reduction fraction must be between (0, 1)!"));
             }
-
-          AssertThrow( (maximum_grain_size_reduction_work_fraction > 0. && maximum_grain_size_reduction_work_fraction < 1.),
-                       ExcMessage("Error: Maximum grain size reduction fraction must be between (0, 1)!"));
-
-          AssertThrow( (minimum_grain_size_reduction_work_fraction > 0. && minimum_grain_size_reduction_work_fraction < 1.),
-                       ExcMessage("Error: Minimum grain size reduction fraction must be between (0, 1)!"));
 
           // rheology parameters
           dislocation_viscosity_iteration_threshold = prm.get_double("Dislocation viscosity iteration threshold");


### PR DESCRIPTION
These assert currently fail for all tests, because they are executed even if the damage formulation is not selected. This change only executes them if the damage formulation is selected.