### PR TITLE
added a test for the grain size growth of pinned damage formulation

### DIFF
--- a/tests/grain_size_growth_pinned.prm
+++ b/tests/grain_size_growth_pinned.prm
@@ -1,0 +1,33 @@
+# This is a very simple test case that checks
+# that the implementation of the grain growth
+# laws with pinned grain damage formulation 
+# (Mulyukova and Bercovici (2018) are correct. 
+# All parameters, including temperature and pressure, are 
+# set to constant values and no dynamic recrystallisation 
+# is included (the reciprocal required strain is
+# set to zero). Material flows in from the left
+# and flows out at the right boundary with a constant
+# velocity. The grain size
+# should then only depend on the x coordinate
+# following the relation
+#
+# d(x) = (d_0 + A * x)^(1/p)
+#
+# with
+# d_0 = 8e-5 m         (initial grain size)
+# p   = 10             (grain size exponent)
+# A   = 2.0294e-46 1/m
+#
+# leading to a grain size of d=8.8957E-5 m at the
+# right boundary of the model.
+
+include $ASPECT_SOURCE_DIR/tests/grain_size_growth.prm
+
+subsection Material model
+  set Model name = grain size
+
+  subsection Grain size model
+    set Grain size evolution formulation  = pinned grain damage
+    
+  end
+end

--- a/tests/grain_size_growth_pinned/screen-output
+++ b/tests/grain_size_growth_pinned/screen-output
@@ -1,0 +1,63 @@
+
+Number of active cells: 1,024 (on 6 levels)
+Number of degrees of freedom: 17,989 (8,450+1,089+4,225+4,225)
+
+*** Timestep 0:  t=0 years, dt=0 years
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 0 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 28+0 iterations.
+
+   Postprocessing:
+     Compositions min/max/mass: 8e-05/8e-05/8e+05
+     Temperature min/avg/max:   1600 K, 1600 K, 1600 K
+     RMS, max velocity:         0.1 m/year, 0.1 m/year
+
+*** Timestep 1:  t=15625 years, dt=15625 years
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 16 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+0 iterations.
+
+   Postprocessing:
+     Compositions min/max/mass: 8e-05/8.023e-05/8.023e+05
+     Temperature min/avg/max:   1600 K, 1600 K, 1600 K
+     RMS, max velocity:         0.1 m/year, 0.1 m/year
+
+*** Timestep 2:  t=31250 years, dt=15625 years
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 15 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+0 iterations.
+
+   Postprocessing:
+     Compositions min/max/mass: 8e-05/8.046e-05/8.045e+05
+     Temperature min/avg/max:   1600 K, 1600 K, 1600 K
+     RMS, max velocity:         0.1 m/year, 0.1 m/year
+
+*** Timestep 3:  t=46875 years, dt=15625 years
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 16 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+0 iterations.
+
+   Postprocessing:
+     Compositions min/max/mass: 8e-05/8.068e-05/8.066e+05
+     Temperature min/avg/max:   1600 K, 1600 K, 1600 K
+     RMS, max velocity:         0.1 m/year, 0.1 m/year
+
+*** Timestep 4:  t=50000 years, dt=3125.02 years
+   Solving temperature system... 0 iterations.
+   Solving grain_size system ... 6 iterations.
+   Rebuilding Stokes preconditioner...
+   Solving Stokes system... 0+0 iterations.
+
+   Postprocessing:
+     Compositions min/max/mass: 8e-05/8.072e-05/8.07e+05
+     Temperature min/avg/max:   1600 K, 1600 K, 1600 K
+     RMS, max velocity:         0.1 m/year, 0.1 m/year
+
+Termination requested by criterion: end time
+
+
+

--- a/tests/grain_size_growth_pinned/statistics
+++ b/tests/grain_size_growth_pinned/statistics
@@ -1,0 +1,26 @@
+# 1: Time step number
+# 2: Time (years)
+# 3: Time step size (years)
+# 4: Number of mesh cells
+# 5: Number of Stokes degrees of freedom
+# 6: Number of temperature degrees of freedom
+# 7: Number of degrees of freedom for all compositions
+# 8: Iterations for temperature solver
+# 9: Iterations for composition solver 1
+# 10: Iterations for Stokes solver
+# 11: Velocity iterations in Stokes preconditioner
+# 12: Schur complement iterations in Stokes preconditioner
+# 13: Minimal value for composition grain_size
+# 14: Maximal value for composition grain_size
+# 15: Global mass for composition grain_size
+# 16: Minimal temperature (K)
+# 17: Average temperature (K)
+# 18: Maximal temperature (K)
+# 19: Average nondimensional temperature (K)
+# 20: RMS velocity (m/year)
+# 21: Max. velocity (m/year)
+0 0.000000000000e+00 0.000000000000e+00 1024 9539 4225 4225 0  0         27 29 29 8.00000000e-05 8.00001000e-05 8.00000505e+05 1.60000000e+03 1.60000000e+03 1.60000000e+03 1.43725459e-15 1.00000005e-01 1.00000036e-01 
+1 1.562499433166e+04 1.562499433166e+04 1024 9539 4225 4225 0 16 4294967295  0  0 8.00000000e-05 8.02343184e-05 8.02300191e+05 1.60000000e+03 1.60000000e+03 1.60000000e+03 1.43725459e-15 1.00000005e-01 1.00000036e-01 
+2 3.124998866333e+04 1.562499433166e+04 1024 9539 4225 4225 0 15 4294967295  0  0 8.00000000e-05 8.04606157e-05 8.04499356e+05 1.60000000e+03 1.60000000e+03 1.60000000e+03 1.43725459e-15 1.00000005e-01 1.00000036e-01 
+3 4.687498299499e+04 1.562499433166e+04 1024 9539 4225 4225 0 16 4294967295  0  0 8.00000000e-05 8.06807324e-05 8.06610203e+05 1.60000000e+03 1.60000000e+03 1.60000000e+03 1.43725459e-15 1.00000005e-01 1.00000036e-01 
+4 5.000000000000e+04 3.125017005006e+03 1024 9539 4225 4225 0  6 4294967295  0  0 8.00000000e-05 8.07243088e-05 8.07024080e+05 1.60000000e+03 1.60000000e+03 1.60000000e+03 1.43725459e-15 1.00000005e-01 1.00000036e-01 


### PR DESCRIPTION
I added a test for the grain size growth of the new pinned damage formulation. The output should be the same to grain size growth test (using Grain size evolution formulation = paleowattmeter).