### PR TITLE
cleanup

### DIFF
--- a/include/aspect/material_model/grain_size.h
+++ b/include/aspect/material_model/grain_size.h
@@ -277,18 +277,20 @@ namespace aspect
 
         /**
          * Functions and parameters controlling conversion from interface roughness to grain size,
-         * used in pinned state formulation of grain damage.
-         * The function roughness_to_grain_size_factor () returns the factor used to convert roughness
-         * into the euivalent mean grain size for a given volume fraction of a mineral in the two-phase
-         * damage model.
+         * used in pinned state formulation of grain damage. This conversion depends on the
+         * proportion of the two mineral phases.
          *
-         * Detailed description of this approach can be found in Appendix H.1, eqs 8, F.28  of
-         * Bercovici, David, and Yanick Ricard (2012).
+         * A detailed description of this approach can be found in Appendix H.1, in Equation (8) in
+         * the main manuscript, and in equation (F.28) of Bercovici, David, and Yanick Ricard (2012).
          * Mechanisms for the generation of plate tectonics by two-phase grain-damage
          * and pinning. Physics of the Earth and Planetary Interiors 202 (2012): 27-55.
          */
         double                                   volume_fraction_phase_one;
 
+        /**
+         * This function returns the factor used to convert roughness into the equivalent mean grain
+         * size for a given volume fraction of a mineral in the two-phase damage model.
+         */
         double roughness_to_grain_size_factor    (const double volume_fraction_phase_one) const;
 
         double phase_distribution_function       (const double volume_fraction_phase_one) const;

--- a/source/material_model/grain_size.cc
+++ b/source/material_model/grain_size.cc
@@ -326,11 +326,9 @@ namespace aspect
           // in the two-phase damage model grain growth depends on the proportion of the two phases
           if (grain_size_evolution_formulation == Formulation::pinned_grain_damage)
             grain_size_growth_rate *= geometric_constant[phase_index] * phase_distribution_function (volume_fraction_phase_one) /
-                                      std::pow(roughness_to_grain_size_factor(volume_fraction_phase_one), m)
+                                      std::pow(roughness_to_grain_size_factor(volume_fraction_phase_one), m);
 
-
-
-                                      const double grain_size_growth = grain_size_growth_rate * grain_growth_timestep;
+          const double grain_size_growth = grain_size_growth_rate * grain_growth_timestep;
 
           // grain size reduction in dislocation creep regime
           const SymmetricTensor<2,dim> shear_strain_rate = strain_rate - 1./dim * trace(strain_rate) * unit_symmetric_tensor<dim>();


### PR DESCRIPTION
There was a semicolon missing in #5. 
This PR fixes this and improves some documentation. 